### PR TITLE
Support for custom subscription parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ See the [demo](http://treeview.meteor.qnipp.com) to see different configurations
 
 - **collection** sets the collection to be used.
 - **subscription** sets the subscription for the template.
+- **subscriptionParameters** can be used to pass any optional subscription parameters. For multiple parameters use an object.
 - **processNode** is a `function(node, item)` that allows to modify the tree nodes (node parameter) for jsTree, e.g. for adding properties to it for a certain plugin. The database item is passed as item.
 - **getNodes** is a `function(parent)`, which returns the nodes for a given parent as cursor or array.
 - **mapping** contains a mapping from the fields from the data source to the tree fields. If a string is set, this field is taken from the orginal data. If a function is given, the function is called with the signature `function(item)`. `item` is the row in the database.

--- a/client/tree_view.js
+++ b/client/tree_view.js
@@ -15,7 +15,7 @@ Template.TreeView.onCreated(function() {
     if (dataContext && dataContext.collection) {
       if (dataContext.subscription) {
         //console.log('Calling subscribe');
-        instance.subscribe(dataContext.subscription, {
+        instance.subscribe(dataContext.subscription, dataContext.subscriptionParameters, {
           onReady: () => {
             //console.log("onReady called");
             //console.debug(this);


### PR DESCRIPTION
Currently I couldn't find a proper way to pass parameters to subscription. Easiest way seemed to be adding a new configuration entry. 
Example:
    treeArgs() {
        config = {
            collection: MyCollection,
            subscription: 'mySubscription',
            subscriptionParameters: { 
                someParam: Session.get('someVariable'),
                otherParam: otherVar
            },
            ...